### PR TITLE
Add --no-newline command line option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "progredient"
-version = "1.0.1-dev"
+version = "1.1.0"
 dependencies = [
  "progressing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "progredient"
-version = "1.1.0"
+version = "1.1.1-dev"
 dependencies = [
  "progressing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "progredient"
-version = "1.0.1-dev"
+version = "1.1.0"
 edition = "2021"
 license = "MIT"
 description = "A program to render text progress bars."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "progredient"
-version = "1.1.0"
+version = "1.1.1-dev"
 edition = "2021"
 license = "MIT"
 description = "A program to render text progress bars."

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Optional arguments:
 --style ABCDE     render the bar as "ABBBBBBCDDDE" with C positioned at --at
 --label LABEL     show this text after the bar
 --left            show the label before the bar instead
+--no-newline      do not print a newline after the bar
 ```
 
 ## Examples

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ pub struct Config {
     pub label: String,
     pub label_placement: LabelPlacement,
     pub style: String,
+    pub no_newline: bool,
 }
 pub enum LabelPlacement {
     Left,
@@ -23,6 +24,7 @@ impl Default for Config {
             label: String::from(""),
             label_placement: LabelPlacement::Right,
             style: String::from("[=>.]"),
+            no_newline: false,
         }
     }
 }
@@ -76,6 +78,7 @@ pub fn from_argv() -> ParseResult {
             "--left" => cfg.label_placement = LabelPlacement::Left,
             "--style" => cfg.style = expect_param("--style", args.next().as_ref()),
             "--help" | "-h" | "/?" => return ParseResult::ShowHelp,
+            "--no-newline" => cfg.no_newline = true,
             arg => return ParseResult::ErrorUnknownArgument(arg.to_owned()),
         }
     }
@@ -95,6 +98,7 @@ Optional arguments:
 --label LABEL     show this text after the bar
 --left            show the label before the bar instead
 --help            show this information and exit
+--no-newline      do not print a newline after the bar
 "
     .to_owned()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,4 @@
-use std::{env, fmt::Debug, process::exit, str::FromStr};
-
+use std::{env, fmt::Debug, str::FromStr};
 pub struct Config {
     pub from: i32,
     pub to: i32,
@@ -9,10 +8,23 @@ pub struct Config {
     pub label_placement: LabelPlacement,
     pub style: String,
 }
-
 pub enum LabelPlacement {
     Left,
     Right,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            from: 0,
+            to: 100,
+            at: 0,
+            length: 20,
+            label: String::from(""),
+            label_placement: LabelPlacement::Right,
+            style: String::from("[=>.]"),
+        }
+    }
 }
 
 fn expect_param<T>(desc: &str, param: Option<&String>) -> T
@@ -20,7 +32,7 @@ where
     T: FromStr,
     <T as FromStr>::Err: Debug,
 {
-    let param = param.unwrap_or_else(|| panic!("{} needs a parameter", desc));
+    let param = param.unwrap_or_else(|| panic!("{desc} needs a parameter"));
     let param = T::from_str(param);
 
     param.unwrap_or_else(|_| {
@@ -32,16 +44,14 @@ where
     })
 }
 
-pub fn configure_from_argv() -> Config {
-    let mut cfg = Config {
-        length: 20,
-        from: 0,
-        to: 20,
-        at: 0,
-        label: String::from(""),
-        label_placement: LabelPlacement::Right,
-        style: String::from("[=>.]"),
-    };
+pub enum ParseResult {
+    Ok(Config),
+    ShowHelp,
+    ErrorUnknownArgument(String),
+}
+
+pub fn from_argv() -> ParseResult {
+    let mut cfg = Config::default();
 
     let mut args = env::args();
 
@@ -65,17 +75,16 @@ pub fn configure_from_argv() -> Config {
             "--label" => cfg.label = expect_param("--label", args.next().as_ref()),
             "--left" => cfg.label_placement = LabelPlacement::Left,
             "--style" => cfg.style = expect_param("--style", args.next().as_ref()),
-            "--help" | "-h" | "/?" => print_usage_and_exit(0),
-            _ => print_usage_and_exit(1),
+            "--help" | "-h" | "/?" => return ParseResult::ShowHelp,
+            arg => return ParseResult::ErrorUnknownArgument(arg.to_owned()),
         }
     }
 
-    cfg
+    ParseResult::Ok(cfg)
 }
 
-fn print_usage_and_exit(code: i32) {
-    println!(
-        "
+pub fn usage() -> String {
+    "
 Usage:
 progredient --at X%
 progredient --at Y --from X --to Z
@@ -87,7 +96,5 @@ Optional arguments:
 --left            show the label before the bar instead
 --help            show this information and exit
 "
-    );
-
-    exit(code)
+    .to_owned()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,29 @@
+pub mod config;
+
+use progressing::{clamping::Bar as ClampingBar, Baring};
+
+pub fn render(cfg: &config::Config) -> String {
+    let config::Config {
+        from,
+        to,
+        at,
+        length,
+        label,
+        label_placement,
+        style,
+        ..
+    } = cfg;
+
+    let mut progress_bar = ClampingBar::new();
+
+    progress_bar.set((at - from) as f64 / (to - from) as f64);
+
+    progress_bar.set_len(*length);
+    progress_bar.set_style(style);
+
+    match label_placement {
+        _ if label.is_empty() => format!("{progress_bar}"),
+        config::LabelPlacement::Left => format!("{label} {progress_bar}"),
+        config::LabelPlacement::Right => format!("{progress_bar} {label}"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,3 +27,65 @@ pub fn render(cfg: &config::Config) -> String {
         config::LabelPlacement::Right => format!("{progress_bar} {label}"),
     }
 }
+
+#[test]
+fn test_render_default_cfg() {
+    let cfg = config::Config::default();
+
+    let output = render(&cfg);
+
+    assert_eq!(output, "[>.................]");
+}
+
+#[test]
+fn test_render_from_to_at() {
+    let cfg = config::Config {
+        from: 0,
+        to: 100,
+        at: 50,
+        ..config::Config::default()
+    };
+
+    let output = render(&cfg);
+
+    assert_eq!(output, "[=========>........]");
+}
+
+#[test]
+fn test_render_length() {
+    let cfg = config::Config {
+        length: 10,
+        ..config::Config::default()
+    };
+
+    let output = render(&cfg);
+
+    assert_eq!(output, "[>.......]");
+}
+
+#[test]
+fn test_render_label() {
+    let cfg = config::Config {
+        label: String::from("test"),
+        ..config::Config::default()
+    };
+
+    let output = render(&cfg);
+
+    assert_eq!(output, "[>.................] test");
+}
+
+#[test]
+fn test_render_style() {
+    let cfg = config::Config {
+        from: 0,
+        to: 100,
+        at: 50,
+        style: String::from("()+ }"),
+        ..config::Config::default()
+    };
+
+    let output = render(&cfg);
+
+    assert_eq!(output, "()))))))))+        }");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,5 +17,9 @@ fn main() {
 
     let output = progredient::render(&cfg);
 
-    println!("{output}");
+    if cfg.no_newline {
+        print!("{output}");
+    } else {
+        println!("{output}");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,8 @@ fn main() {
             process::exit(0);
         }
         progredient::config::ParseResult::ErrorUnknownArgument(arg) => {
-            println!("Unknown argument: {arg}");
+            println!("ERROR: Unknown argument: {arg}");
+            println!("{}", config::usage());
             process::exit(64);
         }
         progredient::config::ParseResult::Ok(cfg) => cfg,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,21 @@
-use config::configure_from_argv;
-use progressing::{clamping::Bar as ClampingBar, Baring};
+use std::process;
 
-use crate::config::LabelPlacement;
-
-mod config;
+use progredient::{self, config};
 
 fn main() {
-    let config::Config {
-        from,
-        to,
-        at,
-        length,
-        label,
-        label_placement,
-        style,
-    } = configure_from_argv();
-
-    let mut progress_bar = ClampingBar::new();
-
-    progress_bar.set((at - from) as f64 / (to - from) as f64);
-
-    progress_bar.set_len(length);
-    progress_bar.set_style(style);
-
-    let output = match label_placement {
-        _ if label.is_empty() => format!("{}", progress_bar),
-        LabelPlacement::Left => format!("{} {}", label, progress_bar),
-        LabelPlacement::Right => format!("{} {}", progress_bar, label),
+    let cfg = match config::from_argv() {
+        progredient::config::ParseResult::ShowHelp => {
+            println!("{}", config::usage());
+            process::exit(0);
+        }
+        progredient::config::ParseResult::ErrorUnknownArgument(arg) => {
+            println!("Unknown argument: {arg}");
+            process::exit(64);
+        }
+        progredient::config::ParseResult::Ok(cfg) => cfg,
     };
 
-    println!("{}", output);
+    let output = progredient::render(&cfg);
+
+    println!("{output}");
 }


### PR DESCRIPTION
Give better control for simpler integration in scripts, e.g. if updating a progress bar in place.